### PR TITLE
[TestGen] Add API and UI tests for item verification

### DIFF
--- a/ApiTests/DataApiTests.cs
+++ b/ApiTests/DataApiTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace ApiTests
+{
+    [TestFixture]
+    public class DataApiTests : UiTestBase
+    {
+        [Test]
+        public async Task Test_PostDataItem()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "This is a test description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("id", out JsonElement idProperty), "Response does not contain 'id'");
+            Assert.IsTrue(responseBody.TryGetProperty("name", out JsonElement nameProperty), "Response does not contain 'name'");
+            Assert.AreEqual(payload.Name, nameProperty.GetString(), "The name of the created item does not match");
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+
+        [Test]
+        public async Task Test_GetDataItems()
+        {
+            // Act
+            var response = await API.GetAsync("/api/data");
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.ValueKind == JsonValueKind.Array, "Response is not an array");
+            Assert.IsTrue(responseBody.GetArrayLength() > 0, "Response array is empty");
+
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+        }
+    }
+}

--- a/UiTests/DataUiTests.cs
+++ b/UiTests/DataUiTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using Microsoft.Playwright;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using TestBase;
+using Models;
+
+namespace UiTests
+{
+    [TestFixture]
+    public class DataUiTests : UiTestBase
+    {
+        [Test]
+        public async Task Test_VerifyCreatedItemIsVisible()
+        {
+            // Arrange
+            var payload = new CreateDataItemRequest
+            {
+                Name = "Test Item " + Guid.NewGuid(),
+                Description = "This is a test description"
+            };
+
+            var options = new APIRequestContextOptions
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                },
+                Data = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                })
+            };
+
+            // Act
+            var response = await API.PostAsync("/api/data", options);
+            JsonElement responseBody = (JsonElement)await response.JsonAsync();
+
+            // Assert
+            Assert.IsTrue(responseBody.TryGetProperty("id", out JsonElement idProperty), "Response does not contain 'id'");
+            var itemId = idProperty.GetInt32();
+            Assert.IsTrue(responseBody.TryGetProperty("name", out JsonElement nameProperty), "Response does not contain 'name'");
+            var itemName = nameProperty.GetString();
+
+            TestContext.WriteLine("📤 Request Payload:\n" + JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+            TestContext.WriteLine("📥 Response Body:\n" + responseBody.ToString());
+
+            // Navigate to the UI
+            await Page.GotoAsync("http://localhost:5000");
+            TestContext.WriteLine("🌐 Navigating to UI: http://localhost:5000");
+
+            // Verify the item appears in the list
+            var itemSelector = $"li[data-item-id='{itemId}']";
+            var itemElement = await Page.QuerySelectorAsync(itemSelector);
+            Assert.IsNotNull(itemElement, $"Item with ID {itemId} not found in the UI");
+            Assert.AreEqual(itemName, await itemElement.InnerTextAsync(), "The name of the item in the UI does not match");
+
+            // Highlight the item
+            await Page.EvalOnSelectorAsync(itemSelector, "el => el.style.border = '3px solid red'");
+            TestContext.WriteLine($"🔍 Verifying item with selector: {itemSelector}");
+
+            // Capture screenshot
+            var screenshotPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            await Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            TestContext.WriteLine($"📸 Screenshot saved at: {screenshotPath}");
+            TestContext.AddTestAttachment(screenshotPath);
+
+            TestContext.WriteLine("✅ UI verification successful.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following tests:

**API Tests**:
1. `Test_PostDataItem` in `ApiTests/DataApiTests.cs`
   - Verifies that a data item can be created via the `POST /api/data` endpoint.
   - Asserts that the response contains the correct `id` and `name`.
   - Logs request and response payloads.

2. `Test_GetDataItems` in `ApiTests/DataApiTests.cs`
   - Verifies that data items can be retrieved via the `GET /api/data` endpoint.
   - Asserts that the response is a non-empty array.
   - Logs the response payload.

**UI Test**:
1. `Test_VerifyCreatedItemIsVisible` in `UiTests/DataUiTests.cs`
   - Creates a data item via the API and verifies its visibility in the UI.
   - Asserts that the item is present and its name matches.
   - Highlights the item and captures a screenshot, attaching it to the test results.

These tests ensure that the API endpoints for creating and retrieving data items are functioning correctly and that created items are visible in the UI.